### PR TITLE
Fix GA tracking ID

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,7 @@ extra:
       link: https://www.linkedin.com/company/readysettech/
   analytics:
     provider: google
-    property: G-316711760
+    property: G-QHKR2RLDNK
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Previously, we were using the property ID, which
isn't the same as the tracking ID.