### PR TITLE
Update quickstart prerequisites

### DIFF
--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -22,8 +22,15 @@ First, you'll start a local deployment using the ReadySet orchestrator.(1) Then 
 
 ## Before you begin
 
-- Install and start [Docker](https://docs.docker.com/get-docker/).
-- Install the [MySQL shell](https://dev.mysql.com/doc/refman/8.0/en/mysql.html) or the [Postgres shell](https://www.postgresql.org/docs/current/app-psql.html), depending on which database you plan to use.
+=== "MySQL"
+
+    - Install [Docker Engine](https://docs.docker.com/engine/install/) for your OS.
+    - Install the [MySQL shell](https://dev.mysql.com/doc/refman/8.0/en/mysql.html).
+
+=== "Postgres"
+
+    - Install [Docker Engine](https://docs.docker.com/engine/install/) for your OS.
+    - Install the [Postgres shell](https://www.postgresql.org/docs/current/app-psql.html).
 
 ## Step 1. Deploy ReadySet
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -1,4 +1,4 @@
-# Quickstart
+# Quickstart with ReadySet
 
 This tutorial shows you the quickest way to get started with ReadySet.
 
@@ -14,11 +14,9 @@ First, you'll start a local deployment using the ReadySet orchestrator.(1) Then 
 
     The orchestrator also gives you the choice to create a new MySQL or Postgres database or connect to an existing database.
 
-??? tip "Interested in cloud deployment?"
+!!! tip
 
-    You can deploy to AWS yourself using our Kubernetes Helm chart, or you can let ReadySet do the work on ReadySet Cloud.
-
-    See [Deploy with Kubernetes](deploy-readyset-kubernetes.md) or [Deploy on ReadySet Cloud](deploy-readyset-cloud.md) for more details.
+    To deploy ReadySet on AWS, use our [Kubernetes Helm chart](deploy-readyset-kubernetes.md), or let ReadySet do the work on [ReadySet Cloud](deploy-readyset-cloud.md).
 
 ## Before you begin
 


### PR DESCRIPTION
- Users need Docker and Docker Compose. Previously, we were pointing to the page for downloading Docker Desktop, which gives you what you need on Mac, Windows, and some but not all Linux distros. To get around this, we now point users to the Docker Engine install.
- Added MySQL and Postgres toggles to the prereqs.

Fixes https://readysettech.atlassian.net/browse/DOC-47.