### PR TITLE
Add tip about cloud on helm tutorial

### DIFF
--- a/docs/guides/deploy-readyset-kubernetes.md
+++ b/docs/guides/deploy-readyset-kubernetes.md
@@ -1,8 +1,12 @@
 # Deploy ReadySet with Kubernetes
 
-This page shows you how to run ReadySet on [Amazon EKS](https://aws.amazon.com/eks/) in front of an [Amazon RDS](https://aws.amazon.com/rds/) for Postgres or MySQL database.
+This page shows you how to run ReadySet yourself on [Amazon EKS](https://aws.amazon.com/eks/) in front of an [Amazon RDS](https://aws.amazon.com/rds/) for Postgres or MySQL database.
 
 First, you'll start a Kubernetes cluster on Amazon EKS with enough resources for a simple ReadySet deployment. For efficient networking and security, you'll use the same VPC as your database. Next, you'll set up load balancing to handle traffic from outside of the Kubernetes cluster. Then you'll configure your database to ensure that ReadySet can consume the database's replication stream. Finally, you'll use ReadySet's Helm chart to deploy ReadySet into the Kubernetes cluster.
+
+!!! tip
+
+    If you don't want to run and manage ReadySet yourself, get a fully-managed deployment on [ReadySet Cloud](deploy-readyset-cloud.md).
 
 ## Before you begin
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,8 +50,8 @@ nav:
     - Quickstart: guides/quickstart.md
   - Run ReadySet:
     - Deploy on AWS:
-        - Kubernetes: guides/deploy-readyset-kubernetes.md
-        - ReadySet Cloud: guides/deploy-readyset-cloud.md
+        - with ReadySet Cloud: guides/deploy-readyset-cloud.md
+        - with Kubernetes: guides/deploy-readyset-kubernetes.md
     - Connect an App: guides/connect-an-app.md
     - Cache Queries: guides/cache-queries.md
   # - Manage ReadySet:


### PR DESCRIPTION
As a first step to clarifying the different between helm and cloud deployments, this PR adds a tip on the helm page pointing to cloud as the managed offering.