### PR TITLE
Link from logo to readyset.io

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ extra_css:
 copyright: © 2022 ReadySet Technology Inc.
 
 extra:
+  homepage: https://readyset.io/
   social:
     - icon: fontawesome/brands/discord
       link: https://discord.gg/readyset


### PR DESCRIPTION
Previously, we were linking to the docs home, and there was no easy way to get to the rest of the site.