### PR TITLE
Change readyset-adapter to readyset in quickstart and Helm tutorial

### DIFF
--- a/docs/guides/deploy-readyset-kubernetes.md
+++ b/docs/guides/deploy-readyset-kubernetes.md
@@ -534,8 +534,8 @@ In this step, you'll download and edit the configuration files for deploying Rea
         The results will look like this:
 
         ``` {.text .no-copy}
-        {"name":"readyset/readyset-server","tags":["d3f36b07c8edd41c9ec558654b0cd6b1998eee61","latest"]}
-        {"name":"readyset/readyset","tags":["d3f36b07c8edd41c9ec558654b0cd6b1998eee61","latest"]}
+        {"name":"readyset/readyset-server","tags":["nightly-2022-11-17","3de80e7d15f1dba1aa5817c78a78cbabb6cdbdc0","nightly-2022-11-04","b2a352d2085c83ac56fb5a5d75aaf96342dbc3c0","nightly-2022-11-03","nightly-2022-11-11","nightly-2022-11-29","nightly-2022-12-08.1","latest",...]}
+        {"name":"readyset/readyset","tags":["nightly-2022-12-07","0.1.0","nightly-2022-12-08.1","latest","nightly-2022-12-07.1","nightly-2022-12-06.2","nightly-2022-12-06.1","nightly-2022-12-08","beta-2022-12-07"]}
         ```
 
     2. In `values.yaml`, change the image tags for the ReadySet Server and Adapter from `latest` to the [most recent version](../releases/readyset-core.md):
@@ -678,7 +678,7 @@ In this step, you'll use the Helm package manager to deploy ReadySet into your E
     ``` {.text .no-copy}
     NAME                                        READY   STATUS    RESTARTS   AGE   IP               NODE                             NOMINATED NODE   READINESS GATES
     readyset-consul-server-0                    1/1     Running   0          5m    192.168.39.169   ip-192-168-43-246.ec2.internal   <none>           <none>
-    readyset-readyset-9dbfb77d9-ml92h   2/2     Running   0          5m    192.168.48.46    ip-192-168-43-246.ec2.internal   <none>           <none>
+    readyset-readyset-adapter-9dbfb77d9-ml92h   2/2     Running   0          5m    192.168.48.46    ip-192-168-43-246.ec2.internal   <none>           <none>
     readyset-readyset-server-0                  2/2     Running   0          5m    192.168.18.133   ip-192-168-18-84.ec2.internal    <none>           <none>
     ```
 
@@ -786,22 +786,22 @@ In this step, you'll use the Helm package manager to deploy ReadySet into your E
         To follow the ReadySet Adapter logs, use:
 
         ``` sh
-        export ADAPTER=$(kubectl get pods | grep readyset | cut -d' ' -f1);
+        export ADAPTER=$(kubectl get pods | grep readyset-adapter | cut -d' ' -f1);
         ```
 
         ``` sh
-        kubectl logs ${ADAPTER} -c readyset -f
+        kubectl logs ${ADAPTER} -c readyset-adapter -f
         ```        
 
 7. Confirm that a load balancer service was created successfully:
 
     ``` sh
-    kubectl get service/readyset-readyset
+    kubectl get service/readyset-readyset-adapter
     ```
 
     ```
     NAME                        TYPE           CLUSTER-IP      EXTERNAL-IP                                                                    PORT(S)                         AGE
-    readyset-readyset   LoadBalancer   10.100.46.222   k8s-default-readyset-3cab417124-2b191c9917ce4d43.elb.us-east-1.amazonaws.com   3306:30336/TCP,5432:30185/TCP   5m
+    readyset-readyset-adapter   LoadBalancer   10.100.46.222   k8s-default-readyset-3cab417124-2b191c9917ce4d43.elb.us-east-1.amazonaws.com   3306:30336/TCP,5432:30185/TCP   5m
     ```
     Do not move on to the next step until an `EXTERNAL-IP` has been assigned to the load balancer. This may take a few minutes.
 
@@ -871,7 +871,7 @@ In this step, you'll use the Helm package manager to deploy ReadySet into your E
         1. Get the IP of the ReadySet Adapter pod:
 
             ``` sh
-            export ADAPTER=$(kubectl get pods | grep readyset | cut -d' ' -f1);
+            export ADAPTER=$(kubectl get pods | grep readyset-adapter | cut -d' ' -f1);
             ```
 
             ``` sh

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -206,11 +206,11 @@ Now that you have a live database with sample data, you'll connect ReadySet to t
     --platform=linux/amd64 \
     --volume='readyset:/state' \
     --pull=always \
-    -e ENGINE=psql \
     -e DEPLOYMENT_ENV=quickstart_docker \
-    public.ecr.aws/readyset/readyset-adapter:latest \
+    public.ecr.aws/readyset/readyset:latest \
     --standalone \
     --deployment='quickstart-postgres' \
+    --database-type=postgresql \
     --upstream-db-url=postgresql://postgres:readyset@postgres:5432/imdb \
     --address=0.0.0.0:5433 \
     --username='postgres' \
@@ -219,13 +219,14 @@ Now that you have a live database with sample data, you'll connect ReadySet to t
     --db-dir='/state'
     ```
 
-2. This `docker run` command is similar to the one you used to start Postgres. However, the environment variables set in the container and the flags following the `readyset-adapter` image are specific to ReadySet. Take a moment to understand them:
+2. This `docker run` command is similar to the one you used to start Postgres. However, the flags following the `readyset` image are specific to ReadySet. Take a moment to understand them:
 
     Flag | Details
     -----|--------
-    `-e` | The `readyset-adapter` image works with both Postgres and MySQL. You set the `ENGINE` environment variable to specify which one you're using. For this tutorial, you also set an environment variable to allow ReadySet to categorize your deployment as a quickstart experience in anonymous [telemetry](../reference/telemetry.md) data.
-    `--standalone` | <p>For [production deployments](deploy-readyset-kubernetes.md), you run the ReadySet Server and Adapter as separate processes. For local testing, however, you can run the Server and Adapter as a single process by passing the `--standalone` flag to the ReadySet Adapter command.</p>
+    `-e` |  For this tutorial, you also set an environment variable to allow ReadySet to categorize your deployment as a quickstart experience in anonymous [telemetry](../reference/telemetry.md) data.
+    `--standalone` | <p>For [production deployments](deploy-readyset-kubernetes.md), you run the ReadySet Server and Adapter as separate processes. For local testing, however, you can run the Server and Adapter as a single process by passing the `--standalone` flag to the `readyset` command.</p>
     `--deployment` | A unique identifier for the ReadySet deployment.
+    `--database-type` | The `readyset` image works with both Postgres and MySQL. You set this flag to specify which one you're using.
     `--upstream-db-url` | <p>The URL for connecting ReadySet to Postgres. This connection URL includes the username and password for ReadySet to authenticate with as well as the database to replicate.</p><div class="admonition tip"><p class="admonition-title">Tip</p><p>By default, ReadySet replicates all tables in all schemas of the specified Postgres database. For this tutorial, that's fine. However, in future deployments, if the queries you want to cache access only a specific schema or specific tables in a schema, or if some tables can't be replicated by ReadySet because they contain [data types](../reference/sql-support/#data-types) that ReadySet does not support, you can narrow the scope of replication by passing `--replication-tables=<schema.table>,<schema.table>`.</p>
     `--address` | The IP and port that ReadySet listens on. For this tutorial, ReadySet is running locally on a different port than Postgres, so connecting `psql` to ReadySet is just a matter of changing the port from `5432` to `5433`.</p>       
     `--username`<br>`--password`| The username and password for connecting clients to ReadySet. For this tutorial, you're using the same username and password for both Postgres and ReadySet.


### PR DESCRIPTION
Change readyset-adapter to readyset in quickstart and Helm tutorial

- Update the readyset command
   - Change the image
   - Change the ENGINE env variable to the --database-type flag
- Update the related text/explanations

Fixes: DOC-83
Fixes: DOC-84