### PR TITLE
Update mkdocs config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,8 +15,11 @@ theme:
     - navigation.top
     - header.autohide
     - content.tabs.link
+    - content.code.copy
     - content.code.annotate
     - content.tooltips
+    - content.action.edit
+    - content.action.view
   font:
     # Fonts for everything but headings
     # Heading fonts defined in stylesheets/extra.css


### PR DESCRIPTION
- Explicitly enable code block copy buttons
- Explicitly enable viewing/editing source icons

These explicit settings are required as of Material for MkDocs 9.x.

Fixes: DOC-92