### PR TITLE
Apply SQL language to snippets in Concepts category

### DIFF
--- a/docs/concepts/efficiency.md
+++ b/docs/concepts/efficiency.md
@@ -10,14 +10,13 @@ useful (i.e., the subset of the results that are commonly read).
 
 What does this look like in practice? Let's come back to the query in the prior section:
 
-```
+```sql
 SELECT id, author, title, url, vcount
 FROM stories
 JOIN (SELECT story_id, COUNT(*) AS vcount
             FROM votes GROUP BY story_id)  
 AS VoteCount
 ON VoteCount.story_id = stories.id WHERE stories.id = ?;
-
 ```
 
 Without partial materialization, ReadySet would have to compute the results for this query for every possible

--- a/docs/concepts/example.md
+++ b/docs/concepts/example.md
@@ -4,23 +4,26 @@ To illustrate these concepts, we will walk through an example of using ReadySet 
 ## Schema
 First we define two tables to keep track of HackerNews stories and votes.
 
-```CREATE TABLE stories (id int, author text, title text, url text); ```
+```sql
+CREATE TABLE stories (id int, author text, title text, url text);
+```
 
-```CREATE TABLE votes (user int, story_id int);```
+```sql
+CREATE TABLE votes (user int, story_id int);
+```
 
 ## Query
 
 Next, we'll write a query that computes the vote count for each story and joins the
 vote counts with other story metadata such as the author, title, and ID.  
 
-```
+```sql
 SELECT id, author, title, url, vcount
 FROM stories
 JOIN (SELECT story_id, COUNT(*) AS vcount
             FROM votes GROUP BY story_id)  
 AS VoteCount
 ON VoteCount.story_id = stories.id WHERE stories.id = ?;
-
 ```
 
 ## Caching with ReadySet

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -92,4 +92,4 @@ Most web applications have a high read-to-write traffic ratio, and therefore fit
 performance improvements in these contexts.
 
 ## Can I try it?
-Yes! ReadySet is source-available under the BSL 1.1 license. Check out our [Github](https://github.com/readysettech/readyset) for more info.
+Yes! ReadySet is source-available under the BSL 1.1 license. Check out our [GitHub](https://github.com/readysettech/readyset) for more info.


### PR DESCRIPTION
Adds the SQL language to some of the code blocks - this is in-line with other snippets and definitely improves readability, as well as going along with the light/dark themes.

Before:

![image](https://user-images.githubusercontent.com/94662631/213180852-dd5479e9-fca4-46ef-9591-6667cdaa9170.png)

After:

![image](https://user-images.githubusercontent.com/94662631/213180898-70e0acb2-e2e9-4b21-b480-b3286d981fb6.png)

Also sneaked in a nit - in `docs/concepts/overview.md`, `Github` => `GitHub`.