### PR TITLE
Guidance for external contributions to docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,16 @@
+# ReadySet Docs Code of Conduct
+
+We value the participation of everyone in the ReadySet community and want to create an environment that is welcoming, enjoyable, and fulfilling. When posting or participating in a community event or online forum, please use the following guidelines:
+
+- Be specific and detailed. Include relevant details in your inquiries (eg. versions, error messages, deployment environment, etc.), and avoid asking off-topic questions in existing discussion threads.
+- Share experiences and knowledge publicly. Everyone can benefit from the exchange of knowledge, so we encourage all community members to share their experience in public channels (on the [ReadySet Community Discord](https://discord.gg/readyset), [GitHub](https://github.com/readysettech), etc.).
+- Collaborate and help each other. If someone lacks knowledge in a particular area, help to educate and collaborate with them.
+- Have patience. Many community members are volunteers, and it may take some time to get a response to your question.
+- Be kind and respectful. Communication should be positive and constructive. Every design or implementation choice carries a trade-off and numerous costs, and there is seldom a right answer.
+- Be good to each other. We will exclude you from interaction if you insult, demean, or harass anyone.
+  Likewise any spamming, trolling, or baiting is not welcome.
+- Finally, if you notice or are experiencing violations of this code of conduct or harassment of any kind, please reach out to **`@jseldess`** on GitHub or email  **`info@readyset.io`** to help resolve the situation.
+
+  Thank you for helping make this a helpful and a welcoming community.
+
+  Adapted from the [MongoDB Code of Conduct](https://www.mongodb.com/community-code-of-conduct) and the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,113 @@
+# Contribute to ReadySet Docs
+
+The ReadySet docs are open source. We welcome your contributions!
+
+## Setup
+
+This section helps you set up the tools you'll need to write the docs and use CockroachDB.
+
+These instructions assume that you use macOS. If you use Linux, use your default package manager to install the packages mentioned in these steps, rather than Homebrew.
+
+1. Install [Homebrew](https://brew.sh/), a macOS package manager you'll use for a few different installations:
+
+    ``` sh
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+    ```
+
+1. Install the latest version of Git from Homebrew:
+
+    ``` sh
+    brew install git
+    ```
+
+    You can find instructions to install [git](https://www.atlassian.com/git/tutorials/install-git) for Linux or other operating systems.
+
+1. Install the [MkDocs](https://www.mkdocs.org/) static site generator and the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme:
+
+    ``` sh
+    pip3 install mkdocs
+    pip3 install mkdocs-material
+    ```
+
+## Get started
+
+Once you're ready to contribute:
+
+1. Fork the [ReadySet docs repository](https://github.com/readysettech/docs).
+
+1. [Create a local clone](https://help.github.com/articles/cloning-a-repository/) of your fork.
+
+1. Create a new local branch for your work:
+
+    ``` sh
+    cd path/to/docs
+    git checkout -b "<your branch name>"
+    ```
+
+1. Make your changes in the text editor of your choice (e.g., [Atom](https://atom.io/), [Sublime Text](https://www.sublimetext.com/)).
+
+
+1. Check the files you've changed:
+
+    ``` sh
+    git status
+    ```
+
+1. Stage your changes for commit:
+
+    ``` sh
+    git add <filename>
+    ```
+
+1. Commit your changes:
+
+    ``` sh
+    git commit -m "<concise message describing changes>"
+    ```
+
+1. Use MkDocs to [build a version of the site locally](#build-and-test-the-docs-locally) so you can view your changes in a browser:
+
+    ``` sh
+    mkdocs serve -s
+    ```
+
+1. [Push your local branch to your remote fork](https://help.github.com/articles/pushing-to-a-remote/).
+
+1. Back in your fork of the ReadySet docs repo in the GitHub UI, [open a pull request](https://github.com/readysettech/docs/pulls) and assign it to `jseldess`. If you check the `Allow edits from maintainers` option when creating your pull request, we'll be able to make minor edits or fixes directly, if it seems easier than commenting and asking you to make those revisions, which can streamline the review process.
+
+We'll review your changes, providing feedback and guidance as necessary.
+
+## Keep contributing
+
+If you want to regularly contribute to the ReadySet docs, there are a few things we recommend:
+
+1. Make it easy to bring updated docs into your fork by tracking us upstream:
+
+    ``` sh
+    git remote add --track master upstream https://github.com/readysettech/docs.git
+    ```
+
+1. When you're ready to make your next round of changes, get our latest docs:
+
+    ``` sh
+    git fetch upstream
+    git merge upstream/master
+    ```
+
+1. Repeat the write, build, push, pull flow from the [Get Started](#get-started) section above.
+
+## Build and Test the Docs Locally
+
+Once you've installed [MkDocs](https://www.mkdocs.org/) and [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) and have a local clone of the docs repository, you can build and test the docs as follows:
+
+1. From the root directory of your clone, run:
+
+    ``` sh
+    mkdocs serve -s
+    ```
+
+1. Go to `http://127.0.0.1:8000/` and manually check your changes.
+
+    When you make additional changes, MkDocs automatically regenerates the HTML content. No need to stop and re-start MkDocs; just refresh your browser.
+
+    Once you're done viewing your changes, use **CTRL-C** to stop the MkDocs server.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
 # ReadySet Docs
 
-This repository contains the source files for the ReadySet user documentation
-available at https://docs.readyset.io/.
+This repository contains the source files for the ReadySet documentation available at [docs.readyset.io](https://docs.readyset.io/).
 
-More info coming soon.
+## Suggest Improvements
 
-### Installation
-To run this site locally, first use pip to install `mkdocs` and `mkdocs-material`. Run
+Want a topic added to the docs? Need additional details or clarification? See an error or other problem? Please [open an issue](https://github.com/readysettech/docs/issues).
 
-```
-pip3 install mkdocs
-pip3 install mkdocs-material
-```
+## Write Docs
 
-then, to run the docs site locally, run `mkdocs serve` or `python3 -m mkdocs serve`
+Want to contribute to the docs? See [CONTRIBUTING](CONTRIBUTING.md) for details about setting yourself up and getting started.
+
+## Join the Community
+
+For questions or support, join us on the [ReadySet Community Discord](https://discord.gg/readyset), post questions on our [Github forum](https://github.com/readysettech/readyset/discussions), or schedule an [office hours chat](https://calendly.com/d/d5n-y44-mbg/office-hours-with-ready-set) with our team.
+
+Everyone is welcome!
+
+## Resources
+
+- [Code of conduct](CODE_OF_CONDUCT.md)
+- [Contributing](CONTRIBUTING.md)

--- a/docs/guides/production-notes.md
+++ b/docs/guides/production-notes.md
@@ -15,7 +15,7 @@ A ReadySet deployment sits between your application and database and contains th
 
 Depending on your workload and needs, these components can be deployed in various ways:
 
-- [Basic](#basic)
+- [Standard](#standard)
 - [Scale out](#scale-out)
 - [Multi-region](#multi-region)
 
@@ -57,7 +57,7 @@ When your application is running across multiple regions, you can run a ReadySet
 
 ReadySet is a memory-intensive application. Size your hardware to comfortably hold your working data in memory.
 
-For testing ReadySet in the [Basic](#basic) deployment pattern, start with 2 GiB of RAM and 2 vCPUs (e.g., the `t3.small` instance on AWS) and scale up with increased data size and workload.
+For testing ReadySet in the [Standard](#standard) deployment pattern, start with 2 GiB of RAM and 2 vCPUs (e.g., the `t3.small` instance on AWS) and scale up with increased data size and workload.
 
 ## Storage
 


### PR DESCRIPTION
Rework README and add CONTRIBUTING and CODE_OF_CONDUCT. 

Unrelated: Rename "Basic" deployment pattern to "Standard".

Fixes: DOC-100