### PR TITLE
Metrics page to explain new Python utility script

### DIFF
--- a/archived-content/quickstart.md
+++ b/archived-content/quickstart.md
@@ -310,7 +310,7 @@ For details about the `readyset` command options, see the [ReadySet Demo](tutori
 
 - Profile and cache queries
 
-    Once you are running queries against ReadySet, connect a database SQL shell to ReadySet and use the custom [`SHOW PROXIED QUERIES`](cache-queries.md#identify-queries-to-cache) SQL command to view the queries that ReadySet has proxied to your upstream database and identify which queries are supported by ReadySet. Then use the custom [`CREATE CACHE`](cache-queries.md#cache-queries_1) SQL command to cache supported queries.
+    Once you are running queries against ReadySet, connect a database SQL shell to ReadySet and use the custom [`SHOW PROXIED QUERIES`](cache-queries.md#check-query-support) SQL command to view the queries that ReadySet has proxied to your upstream database and identify which queries are supported by ReadySet. Then use the custom [`CREATE CACHE`](cache-queries.md#cache-queries_1) SQL command to cache supported queries.
 
     !!! note
 

--- a/archived-content/tutorial.md
+++ b/archived-content/tutorial.md
@@ -361,7 +361,7 @@ With snapshotting finished, ReadySet is ready for caching, so in this step, you'
      (1 row)
     ```
 
-1. Because the query is not yet cached, ReadySet proxied it to the upstream database. Use ReadySet's custom [`SHOW PROXIED QUERIES`](cache-queries.md#identify-queries-to-cache) command to check if ReadySet can cache the query:
+1. Because the query is not yet cached, ReadySet proxied it to the upstream database. Use ReadySet's custom [`SHOW PROXIED QUERIES`](cache-queries.md#check-query-support) command to check if ReadySet can cache the query:
 
     ``` sql
     SHOW PROXIED QUERIES;
@@ -422,7 +422,7 @@ With snapshotting finished, ReadySet is ready for caching, so in this step, you'
     (10 rows)
     ```
 
-1. Use the [`SHOW PROXIED QUERIES`](cache-queries.md#identify-queries-to-cache) command to check if ReadySet can cache the query:
+1. Use the [`SHOW PROXIED QUERIES`](cache-queries.md#check-query-support) command to check if ReadySet can cache the query:
 
     ``` sql
     SHOW PROXIED QUERIES;

--- a/docs/guides/cache-queries.md
+++ b/docs/guides/cache-queries.md
@@ -1,8 +1,12 @@
 # Cache Queries
 
-Once you've started running queries against ReadySet, you can use custom SQL commands to identify the queries that ReadySet supports, cache supported queries, view existing caches, and remove caches from ReadySet.
+Once you've [identified queries](profile-queries.md) that can benefit from caching in ReadySet, use ReadySet's custom SQL commands to check if the queries are supported and then to cache supported queries in ReadySet. There are also custom SQL commands for viewing queries that are already cached, and for removing caches from ReadySet.
 
-## Identify queries to cache
+!!! note
+
+    Queries can be cached in ReadySet only once all tables have finished the initial snapshotting process. To confirm that snapshotting has finished, see [Check Snapshotting](check-snapshotting.md).
+
+## Check query support
 
 To view the queries that ReadySet has proxied to the upstream database and check if such queries can be cached with ReadySet, use:
 

--- a/docs/guides/connect-an-app.md
+++ b/docs/guides/connect-an-app.md
@@ -1,6 +1,6 @@
 # Connect to ReadySet
 
-Once you have a ReadySet instance up and running, the next step is to connect your application. The easiest way to get up and running is to swap out your database connection string to point to ReadySet instead. The specifics of how to do this vary by database client library, ORM, and programming language. Below are a few examples.
+Once you have a ReadySet instance up and running, the next step is to connect your application by swapping out your database connection string to point to ReadySet instead. The specifics of how to do this vary by database client library, ORM, and programming language. Below are a few examples.
 
 ## Python
 

--- a/docs/guides/deploy-readyset-binary.md
+++ b/docs/guides/deploy-readyset-binary.md
@@ -787,7 +787,7 @@ In this step, you'll check the status of the snapshotting process. Snapshotting 
 
 - Profile and cache queries
 
-    Once you are running queries against ReadySet, connect a database SQL shell to ReadySet and use the custom [`SHOW PROXIED QUERIES`](cache-queries.md#identify-queries-to-cache) SQL command to view the queries that ReadySet has proxied to your upstream database and identify which queries are supported by ReadySet. Then use the custom [`CREATE CACHE`](cache-queries.md#cache-queries_1) SQL command to cache supported queries.
+    Once you are running queries against ReadySet, connect a database SQL shell to ReadySet and use the custom [`SHOW PROXIED QUERIES`](cache-queries.md#check-query-support) SQL command to view the queries that ReadySet has proxied to your upstream database and identify which queries are supported by ReadySet. Then use the custom [`CREATE CACHE`](cache-queries.md#cache-queries_1) SQL command to cache supported queries.
 
     !!! note
 

--- a/docs/guides/deploy-readyset-cloud.md
+++ b/docs/guides/deploy-readyset-cloud.md
@@ -329,7 +329,7 @@ On your call with ReadySet, you'll ensure replication is enabled. The steps are 
         psql '<ReadySet connection string>'
         ```
 
-    2. Run ReadySet's custom [`SHOW PROXIED QUERIES`](cache-queries.md#identify-queries-to-cache) command:
+    2. Run ReadySet's custom [`SHOW PROXIED QUERIES`](cache-queries.md#check-query-support) command:
 
         ``` sql
         SHOW PROXIED QUERIES;

--- a/docs/guides/intro.md
+++ b/docs/guides/intro.md
@@ -56,7 +56,7 @@ There are a few ways to check on the initial snapshotting process. See [Check Sn
 
 ## How do you cache queries?
 
-Once the initial snapshotting process is complete and queries are running against ReadySet, connect a database SQL shell to ReadySet and use the custom [`SHOW PROXIED QUERIES`](cache-queries.md#identify-queries-to-cache) SQL command to view the queries that ReadySet has proxied to your upstream database and identify which queries are supported by ReadySet. Then use the custom [`CREATE CACHE`](cache-queries.md#cache-queries_1) SQL command to cache supported queries.
+Once the initial snapshotting process is complete and queries are running against ReadySet, connect a database SQL shell to ReadySet and use the custom [`SHOW PROXIED QUERIES`](cache-queries.md#check-query-support) SQL command to view the queries that ReadySet has proxied to your upstream database and identify which queries are supported by ReadySet. Then use the custom [`CREATE CACHE`](cache-queries.md#cache-queries_1) SQL command to cache supported queries.
 
 !!! note
 

--- a/docs/guides/profile-queries.md
+++ b/docs/guides/profile-queries.md
@@ -1,28 +1,53 @@
 # Profile Queries
 
-While running ReadySet, you can view that instance's metrics. Metrics are emitted for freed memory, packets sent, per-query metrics including latencies, and more.
+After [connecting your app](connect-an-app.md) to ReadySet, profile your app performance and identify queries to cache in ReadySet. Generally, it's best to focus on frequent queries that are too slow and/or that are putting unwanted load on your upstream database.  
 
-!!! note
-    To view metrics, the `--prometheus-metrics` flag must be enabled. To view per-query metrics, the `--query-log` and `--query-log-ad-hoc` flags must be passed.
+If you already have performance monitoring in place, use that tooling to identify queries that can benefit from caching in ReadySet. Otherwise, you can use ReadySet's own metrics endpoint to profile queries.
 
+## Enable ReadySet metrics
 
-## Viewing Metrics
+To enable ReadySet metrics, start ReadySet with the following options:
 
-Metrics are aggregated and available on port `6034` at the `/metrics` endpoint. If running ReadySet locally, navigate to `https://localhost:6034/metrics` in your browser.
+- [`--prometheus-metrics`](../reference/cli/readyset.md#-prometheus-metrics)
+- [`--metrics-address`](../reference/cli/readyset.md#-metrics-address)
 
-## Examining per-query metrics
+To include query-specific execution metrics, also pass:
 
-We have a metrics utility script written in Python that queries this metrics endpoint and displays latencies for queries received by ReadySet.
+- [`--query-log`](../reference/cli/readyset.md#-query-log)
+- [`--query-log-ad-hoc`](../reference/cli/readyset.md#-query-log-ad-hoc)
 
-To run the script, follow these steps.
+## Access ReadySet metrics
 
-1. Install dependencies by running `pip3 install urllib3 tabulate`.
+You can access ReadySet metrics at `<metrics address>/metrics`, where the metrics address is defined by the [`--metrics-address`](../reference/cli/readyset.md#-metrics-address) option (default: `0.0.0.0:6034/metrics`).
 
-2. Run the script with 
+!!! tip
 
-```
-curl -O https://raw.githubusercontent.com/readysettech/docs/main/docs/assets/metrics.py \
-&& python3 metrics.py
-```
+    When [running ReadySet locally](quickstart.md), you can usually access ReadySet metrics at `https://127.0.0.1:6034/metrics` in your browser.
 
-NOTE: If you're running ReadySet in Docker, ensure that port 6034 is exposed.
+## Examine per-query metrics
+
+ReadySet metrics are formatted for easy integration with [Prometheus](https://prometheus.io/). However, the quickest way to examine per-query metrics is to use a simple metrics utility written in Python that queries the metrics endpoint and displays latencies for queries received by ReadySet.
+
+1. Download the metrics utility:
+
+    ``` sh
+    curl -O "https://raw.githubusercontent.com/readysettech/docs/main/docs/assets/metrics.py"
+    ```
+
+1. Install dependencies for the utility:
+
+    ``` sh
+    pip3 install urllib3 tabulate
+    ```
+
+1. Set the `HOST` environment variable to the IP address/hostname portion of [`--metrics-address`](../reference/cli/readyset.md#-metrics-address):
+
+    ``` sh
+    export HOST="<metrics-host>"
+    ```
+
+1. Run the script with
+
+    ``` sh
+    python3 metrics.py --host=${HOST}
+    ```

--- a/docs/guides/profile-queries.md
+++ b/docs/guides/profile-queries.md
@@ -1,0 +1,28 @@
+# Profile Queries
+
+While running ReadySet, you can view that instance's metrics. Metrics are emitted for freed memory, packets sent, per-query metrics including latencies, and more.
+
+!!! note
+    To view metrics, the `--prometheus-metrics` flag must be enabled. To view per-query metrics, the `--query-log` and `--query-log-ad-hoc` flags must be passed.
+
+
+## Viewing Metrics
+
+Metrics are aggregated and available on port `6034` at the `/metrics` endpoint. If running ReadySet locally, navigate to `https://localhost:6034/metrics` in your browser.
+
+## Examining per-query metrics
+
+We have a metrics utility script written in Python that queries this metrics endpoint and displays latencies for queries received by ReadySet.
+
+To run the script, follow these steps.
+
+1. Install dependencies by running `pip3 install urllib3 tabulate`.
+
+2. Run the script with 
+
+```
+curl -O https://raw.githubusercontent.com/readysettech/docs/main/docs/assets/metrics.py \
+&& python3 metrics.py
+```
+
+NOTE: If you're running ReadySet in Docker, ensure that port 6034 is exposed.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -164,7 +164,7 @@ With snapshotting finished, ReadySet is ready for caching, so in this step, you'
      (1 row)
     ```
 
-1. Because the query is not yet cached, ReadySet proxied it to the upstream database. Use ReadySet's custom [`SHOW PROXIED QUERIES`](cache-queries.md#identify-queries-to-cache) command to check if ReadySet can cache the query:
+1. Because the query is not yet cached, ReadySet proxied it to the upstream database. Use ReadySet's custom [`SHOW PROXIED QUERIES`](cache-queries.md#check-query-support) command to check if ReadySet can cache the query:
 
     ``` sql
     SHOW PROXIED QUERIES;
@@ -229,7 +229,7 @@ With snapshotting finished, ReadySet is ready for caching, so in this step, you'
       (10 rows)
     ```
 
-1. Use the [`SHOW PROXIED QUERIES`](cache-queries.md#identify-queries-to-cache) command to check if ReadySet can cache the query:
+1. Use the [`SHOW PROXIED QUERIES`](cache-queries.md#check-query-support) command to check if ReadySet can cache the query:
 
     ``` sql
     SHOW PROXIED QUERIES;

--- a/docs/reference/cli/readyset.md
+++ b/docs/reference/cli/readyset.md
@@ -250,7 +250,7 @@ This option is ignored unless [`--prometheus-metrics`](#-prometheus-metrics) is 
 <div class="option-details" markdown="1">
 When [`--query-caching`](#-query-caching) is set to `"explicit"`, the frequency, in milliseconds, at which to check whether queries that ReadySet has proxied to the upstream database are [supported by ReadySet](../sql-support/#query-caching).
 
-After this check is run on a query, [`SHOW PROXIED QUERIES`](../../guides/cache-queries/#identify-queries-to-cache) returns either `yes` or `no` for `readyset supported`. Before this check is run on a query, or when this check fails for a query (e.g., because it references tables that have not finished snapshotting), `SHOW PROXIED QUERIES` returns `pending` for `readyset supported`.
+After this check is run on a query, [`SHOW PROXIED QUERIES`](../../guides/cache-queries/#check-query-support) returns either `yes` or `no` for `readyset supported`. Before this check is run on a query, or when this check fails for a query (e.g., because it references tables that have not finished snapshotting), `SHOW PROXIED QUERIES` returns `pending` for `readyset supported`.
 
 **Default:** `20000`
 

--- a/docs/reference/sql-support.md
+++ b/docs/reference/sql-support.md
@@ -243,7 +243,7 @@ ReadySet supports [Postgres schemas](https://www.postgresql.org/docs/current/ddl
 
 !!! tip
 
-    After running a query through ReadySet, you can use the [`SHOW PROXIED QUERIES`](../guides/cache-queries/#identify-queries-to-cache) command to check if ReadySet supports the query. ReadySet always proxies unsupported queries to the upstream database.
+    After running a query through ReadySet, you can use the [`SHOW PROXIED QUERIES`](../guides/cache-queries/#check-query-support) command to check if ReadySet supports the query. ReadySet always proxies unsupported queries to the upstream database.
 
 ### Clauses
 
@@ -506,7 +506,7 @@ ReadySet supports the following custom SQL commands:
 Command | Description
 --------|------------
 [`SHOW READYSET TABLES`](../guides/check-snapshotting.md) | Check the snapshotting status of tables.
-[`SHOW PROXIED QUERIES`](../guides/cache-queries.md#identify-queries-to-cache) | View the queries that ReadySet has proxied to the upstream database and identify whether such queries can be cached with ReadySet.
+[`SHOW PROXIED QUERIES`](../guides/cache-queries.md#check-query-support) | View the queries that ReadySet has proxied to the upstream database and identify whether such queries can be cached with ReadySet.
 [`CREATE CACHE`](../guides/cache-queries.md#cache-queries_1) | Cache a query in ReadySet.
 [`SHOW CACHES`](../guides/cache-queries.md#view-cached-queries) | Show all queries that have been cached in ReadySet.
 [`DROP CACHE`](../guides/cache-queries.md#remove-cached-queries) | Remove a cache from ReadySet.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,9 +58,9 @@ nav:
     - Deploy with Kubernetes: guides/deploy-readyset-kubernetes.md
     - Deploy with Binary: guides/deploy-readyset-binary.md
   - Use ReadySet:
-    - Check Snapshotting: guides/check-snapshotting.md
     - Connect an App: guides/connect-an-app.md
     - Profile Queries: guides/profile-queries.md
+    - Check Snapshotting: guides/check-snapshotting.md
     - Cache Queries: guides/cache-queries.md
   # - Manage ReadySet:
   #   - Upgrade ReadySet: guides/upgrade-readyset.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,10 +58,10 @@ nav:
     - Deploy with Kubernetes: guides/deploy-readyset-kubernetes.md
     - Deploy with Binary: guides/deploy-readyset-binary.md
   - Use ReadySet:
-    - Connect an App: guides/connect-an-app.md
     - Check Snapshotting: guides/check-snapshotting.md
-    - Cache Queries: guides/cache-queries.md
+    - Connect an App: guides/connect-an-app.md
     - Profile Queries: guides/profile-queries.md
+    - Cache Queries: guides/cache-queries.md
   # - Manage ReadySet:
   #   - Upgrade ReadySet: guides/upgrade-readyset.md
   #   - Scale ReadySet: guides/scale-readyset.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
     - Connect an App: guides/connect-an-app.md
     - Check Snapshotting: guides/check-snapshotting.md
     - Cache Queries: guides/cache-queries.md
+    - Profile Queries: guides/profile-queries.md
   # - Manage ReadySet:
   #   - Upgrade ReadySet: guides/upgrade-readyset.md
   #   - Scale ReadySet: guides/scale-readyset.md


### PR DESCRIPTION
This is a new page that explains how to access the prometheus metrics for a running ReadySet instance and run the python utility script to view per query latencies.