### PR TITLE
Rename tutorial to demo

### DIFF
--- a/docs/guides/deploy-readyset-cloud.md
+++ b/docs/guides/deploy-readyset-cloud.md
@@ -8,7 +8,7 @@ This page shows you how to get up and running with a fully-managed deployment of
 
 !!! tip
 
-    If you are new to ReadySet, consider running through the [Quickstart](quickstart.md) or [Tutorial](tutorial.md) first.
+    If you are new to ReadySet, consider running through the [Quickstart](quickstart.md) or [Demo](tutorial.md) first.
 
 ## Before you begin
 

--- a/docs/guides/intro.md
+++ b/docs/guides/intro.md
@@ -40,7 +40,7 @@ Integrating with ReadySet is straight-forward:
 
 1.  This is the only required change to your application.   
 
-To run through this process on your local machine, see the [Quickstart](quickstart.md) or [Tutorial](tutorial.md).  
+To run through this process on your local machine, see the [Quickstart](quickstart.md) or [Demo](tutorial.md).  
 
 To run through this process in a cloud deployment, see [Deploy with ReadySet Cloud](deploy-readyset-cloud.md) or [Deploy with Kubernetes](deploy-readyset-kubernetes.md).
 
@@ -52,7 +52,7 @@ Once you have a ReadySet instance up and running, the next step is to connect yo
 
 When you first connect ReadySet to your database, ReadySet stores a snapshot of your database tables on disk. This snapshot will be the basis for ReadySet to cache query results, and ReadySet will keep its snapshot and cache up-to-date automatically by listening to the database's replication stream. Queries can be cached in ReadySet once all tables have finished the initial snapshotting process.
 
-There are a few ways to check on the initial snapshotting process. See [Check Snapshotting](check-snapshotting.md) for more details. 
+There are a few ways to check on the initial snapshotting process. See [Check Snapshotting](check-snapshotting.md) for more details.
 
 ## How do you cache queries?
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -4,7 +4,7 @@ This page shows you how to run ReadySet against a Postgres or MySQL database.
 
 !!! tip
 
-    For a walk-through of ReadySet's capabilities and features, see the [ReadySet Tutorial](tutorial.md) instead.
+    For a walk-through of ReadySet's capabilities and features, see the [ReadySet Demo](tutorial.md) instead.
 
 ## Before you begin
 
@@ -298,7 +298,7 @@ This page shows you how to run ReadySet against a Postgres or MySQL database.
         --db-dir='/state'
         ```
 
-For details about the `readyset` command above, see the [ReadySet Tutorial](tutorial.md#step-2-start-readyset).
+For details about the `readyset` command above, see the [ReadySet Demo](tutorial.md#step-2-start-readyset).
 
 
 ## Next steps

--- a/docs/guides/tutorial-interactive.md
+++ b/docs/guides/tutorial-interactive.md
@@ -1,4 +1,4 @@
-# ReadySet Tutorial
+# ReadySet Demo
 
 <style>
   .md-main__inner {

--- a/docs/guides/tutorial.md
+++ b/docs/guides/tutorial.md
@@ -1,4 +1,4 @@
-# ReadySet Tutorial
+# ReadySet Demo
 
 This page walks you through an end-to-end local deployment of ReadySet.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ ReadySet is a lightweight SQL caching engine that sits between your application 
 
     Connect ReadySet to a local Postgres or MySQL database
 
--   :material-play-circle-outline:{ .lg .middle } [__Tutorial__](guides/tutorial.md)
+-   :material-play-circle-outline:{ .lg .middle } [__Demo__](guides/tutorial.md)
 
     ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,7 @@ nav:
   - Intro:
     - What is ReadySet?: guides/intro.md
     - Quickstart: guides/quickstart.md
-    - Tutorial: guides/tutorial.md
+    - Demo: guides/tutorial.md
   - Run ReadySet:
     - Production Notes: guides/production-notes.md
     - Deploy with ReadySet Cloud: guides/deploy-readyset-cloud.md


### PR DESCRIPTION
Since publishing the new quickstart, the "tutorial" hasn't been getting much traction. It's really more of a demo, so I'm rebranding it as such to see if that drives any additional views/engagements.