### PR TITLE
Feb core release notes

### DIFF
--- a/docs/assets/docker-compose-postgres.yml
+++ b/docs/assets/docker-compose-postgres.yml
@@ -22,7 +22,7 @@ services:
       - ./imdb-postgres.sql:/docker-entrypoint-initdb.d/imdb-postgres.sql
   cache:
     container_name: readyset
-    image: "public.ecr.aws/readyset/readyset:beta-2023-01-18"
+    image: "public.ecr.aws/readyset/readyset:beta-2023-02-15"
     platform: linux/amd64
     ports:
       - "5433:5433"
@@ -33,10 +33,8 @@ services:
       DATABASE_TYPE: postgresql
       UPSTREAM_DB_URL: "postgresql://postgres:readyset@postgres:5432/imdb"
       LISTEN_ADDRESS: "0.0.0.0:5433"
-      ALLOWED_USERNAME: postgres
-      ALLOWED_PASSWORD: readyset
       QUERY_CACHING: explicit
-      # PROMETHEUS_METRICS: "1"
+      PROMETHEUS_METRICS: "1"
       QUERY_LOG: "1"
       QUERY_LOG_AD_HOC: "1"
       DB_DIR: "/state"

--- a/docs/reference/cli/readyset.md
+++ b/docs/reference/cli/readyset.md
@@ -276,6 +276,8 @@ The password for authenticating connections to ReadySet. This can differ from th
 
 This option is ignored when [`--allow-unauthenticated-connections`](#-allow-unauthenticated-connections) is passed.    
 
+**Default:** The username for the upstream database in [`--upstream-db-url`](#-upstream-db-url).
+
 **Env variable:** `ALLOWED_PASSWORD`
 </div>
 
@@ -448,6 +450,8 @@ The URL for connecting ReadySet to to the upstream database. This connection URL
 The username for authenticating connections to ReadySet. This can differ from the username in the database connections string in [`--upstream-db-url`](#-upstream-db-url).
 
 This option is ignored when [`--allow-unauthenticated-connections`](#-allow-unauthenticated-connections) is passed.
+
+**Default:** The username for the upstream database in [`--upstream-db-url`](#-upstream-db-url).
 
 **Env variable:** `ALLOWED_USERNAME`
 </div>

--- a/docs/reference/sql-support.md
+++ b/docs/reference/sql-support.md
@@ -73,7 +73,7 @@ ReadySet can snapshot and replicate tables containing many [MySQL](https://dev.m
     | Type | Supported | Notes |
     |------|-----------|-------|
     | [`INT`<br>`SMALLINT`<br>`BIGINT`](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-INT) | :octicons-check-16: | ReadySet ignores the optional length field. |
-    | [`DECIMAL`<br>`NUMERIC`](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL) | :octicons-check-16: | |
+    | [`DECIMAL`<br>`NUMERIC`](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL) | :octicons-check-16: | ReadySet does not support `DECIMAL`/`NUMERIC` values with a scale greater than 28, i.e., with more than 28 digits to the right of the decimal point.|
     | [`FLOAT`<br>`DOUBLE PRECISION`<br>`REAL`](https://dev.mysql.com/doc/refman/8.0/en/floating-point-types.html) | :octicons-check-16: | |
     | [`SERIAL`<br>`SMALLSERIAL`<br>`BIGSERIAL`](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-SERIAL) | :octicons-check-16: | |
 

--- a/docs/reference/sql-support.md
+++ b/docs/reference/sql-support.md
@@ -26,7 +26,7 @@ ReadySet can snapshot and replicate tables containing many [MySQL](https://dev.m
 
 === "MySQL"
 
-    **Numeric types**
+    #### Numeric types
 
     | Type | Supported | Notes |
     |------|------------|-------|
@@ -35,7 +35,7 @@ ReadySet can snapshot and replicate tables containing many [MySQL](https://dev.m
     | [`FLOAT`<br>`DOUBLE`<br>`REAL`](https://dev.mysql.com/doc/refman/8.0/en/floating-point-types.html) | :octicons-check-16: | |
     | [`BIT`](https://dev.mysql.com/doc/refman/8.0/en/bit-type.html) | :octicons-check-16: | ReadySet ignores the optional length field. |
 
-    **Data and time types**
+    #### Data and time types
 
     | Type | Supported | Notes |
     |------|------------|-------|
@@ -43,7 +43,7 @@ ReadySet can snapshot and replicate tables containing many [MySQL](https://dev.m
     | [`TIME`](https://dev.mysql.com/doc/refman/8.0/en/time.html) | :octicons-check-16: | |
     | [`YEAR`](https://dev.mysql.com/doc/refman/8.0/en/year.html) | :octicons-x-16:| |
 
-    **String types**
+    #### String types
 
     | Type | Supported | Notes |
     |------|------------|-------|
@@ -54,13 +54,13 @@ ReadySet can snapshot and replicate tables containing many [MySQL](https://dev.m
     | [`ENUM`](https://dev.mysql.com/doc/refman/8.0/en/enum.html) | :octicons-check-16: | |
     | [`SET`](https://dev.mysql.com/doc/refman/8.0/en/set.html) | :octicons-x-16: | |
 
-    **JSON types**
+    #### JSON types
 
     | Type | Supported | Notes |
     |------|------------|-------|
     | [`JSON`](https://dev.mysql.com/doc/refman/8.0/en/json.html) | :octicons-check-16: | ReadySet represents this type internally as a normalized string. This can cause different behavior than in MySQL with respect to expressions or sorting. |
 
-    **Spatial types**
+    #### Spatial types
 
     | Type | Supported | Notes |
     |------|------------|-------|
@@ -68,7 +68,7 @@ ReadySet can snapshot and replicate tables containing many [MySQL](https://dev.m
 
 === "Postgres"
 
-    **Numeric types**
+    #### Numeric types
 
     | Type | Supported | Notes |
     |------|-----------|-------|
@@ -77,13 +77,13 @@ ReadySet can snapshot and replicate tables containing many [MySQL](https://dev.m
     | [`FLOAT`<br>`DOUBLE PRECISION`<br>`REAL`](https://dev.mysql.com/doc/refman/8.0/en/floating-point-types.html) | :octicons-check-16: | |
     | [`SERIAL`<br>`SMALLSERIAL`<br>`BIGSERIAL`](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-SERIAL) | :octicons-check-16: | |
 
-    **Monetary types**
+    #### Monetary types
 
     | Type | Supported | Notes |
     |------|-----------|-------|
     | [`MONEY`](https://www.postgresql.org/docs/current/datatype-money.html) | :octicons-x-16: |  |
 
-    **Character types**
+    #### Character types
 
     | Type | Supported | Notes |
     |------|-----------|-------|
@@ -91,38 +91,38 @@ ReadySet can snapshot and replicate tables containing many [MySQL](https://dev.m
     | [`"CHAR"`](https://www.postgresql.org/docs/current/datatype-character.html#DATATYPE-CHARACTER-SPECIAL-TABLE) | :octicons-check-16: | |
     | [`CITEXT`](https://www.postgresql.org/docs/15/citext.html) | :octicons-check-16: | |
 
-    **Binary types**
+    #### Binary types
 
     | Type | Supported | Notes |
     |------|-----------|-------|
     | [`BYTEA`](https://www.postgresql.org/docs/current/datatype-binary.html) | :octicons-check-16: | |
 
-    **Date and time types**
+    #### Date and time types
 
     | Type | Supported | Notes |
     |------|-----------|-------|
     | [`DATE`<br>`TIME`<br>`TIMETZ`<br>`TIMESTAMP`<br>`TIMESTAMPTZ`](https://www.postgresql.org/docs/current/datatype-datetime.html) | :octicons-check-16: | ReadySet ignores the optional precision field. |
     | [`INTERVAL`](https://www.postgresql.org/docs/current/datatype-datetime.html) | :octicons-x-16: | |
 
-    **Boolean types**
+    #### Boolean types
 
     | Type | Supported | Notes |
     |------|-----------|-------|
     | [`BOOLEAN`](https://www.postgresql.org/docs/current/datatype-boolean.html) | :octicons-check-16: | |
 
-    **Enumerated types**
+    #### Enumerated types
 
     | Type | Supported | Notes |
     |------|-----------|-------|
     | [`ENUM`](https://www.postgresql.org/docs/current/datatype-enum.html) | :octicons-check-16: | |
 
-    **Geometric types**
+    #### Geometric types
 
     | Type | Supported | Notes |
     |------|-----------|-------|
     | [`POINT`<br>`LINE`<br>`LSEG`<br>`BOX`<br>`PATH`<br>`POLYGON`<br>`CIRCLE`](https://www.postgresql.org/docs/current/datatype-geometric.html) | :octicons-x-16: | |
 
-    **Network address types**
+    #### Network address types
 
     | Type | Supported | Notes |
     |------|-----------|-------|
@@ -131,62 +131,62 @@ ReadySet can snapshot and replicate tables containing many [MySQL](https://dev.m
     | [`MACADDR`](https://www.postgresql.org/docs/current/datatype-net-types.html#DATATYPE-MACADDR) | :octicons-check-16: | ReadySet represents this type internally as a normalized string. This can cause different behavior than in Postgres with respect to expressions or sorting.|
     | [`MACADDR8`](https://www.postgresql.org/docs/current/datatype-net-types.html#DATATYPE-MACADDR8) | :octicons-x-16: | |
 
-    **Bit string types**
+    #### Bit string types
 
     | Type | Supported | Notes |
     |------|-----------|-------|
     | [`BIT`<br>`BIT VARYING`](https://www.postgresql.org/docs/current/datatype-bit.html) | :octicons-check-16: | ReadySet ignores the optional length field. |
 
-    **Text search types**
+    #### Text search types
 
     | Type | Supported | Notes |
     |------|-----------|-------|
     | [`tsvector`](https://www.postgresql.org/docs/current/datatype-textsearch.html#DATATYPE-TSVECTOR) | :octicons-x-16: | |
     | [`tsquery`](https://www.postgresql.org/docs/current/datatype-textsearch.html#DATATYPE-TSQUERY) | :octicons-x-16: | |
 
-    **UUID types**
+    #### UUID types
 
     | Type | Supported | Notes |
     |------|-----------|-------|
     | [`UUID`](https://www.postgresql.org/docs/current/datatype-uuid.html) | :octicons-check-16: | ReadySet represents this type internally as a normalized string. This can cause different behavior than in Postgres with respect to expressions or sorting. |
 
-    **XML types**
+    #### XML types
 
     | Type | Supported | Notes |
     |------|-----------|-------|
     | [`XML`](https://www.postgresql.org/docs/current/datatype-xml.html) | :octicons-x-16: | |
 
-    **JSON types**
+    #### JSON types
 
     | Type | Supported | Notes |
     |------|------------|-------|
     | [`JSON`<br>`JSONB`](https://www.postgresql.org/docs/current/datatype-json.html) | :octicons-check-16: | ReadySet represents this type internally as a normalized string. This can cause different behavior than in Postgres with respect to expressions or sorting. |
 
-    **Array types**
+    #### Array types
 
     | Type | Supported | Notes |
     |------|------------|-------|
     | [`ARRAY`](https://www.postgresql.org/docs/current/arrays.html) | :octicons-check-16:| |
 
-    **Composite data types**
+    #### Composite data types
 
     | Type | Supported | Notes |
     |------|------------|-------|
     | [`CREATE TYPE <name> AS`](https://www.postgresql.org/docs/current/rowtypes.html) | :octicons-x-16:| |
 
-    **Range types**
+    #### Range types
 
     | Type | Supported | Notes |
     |------|------------|-------|
     | [`INT4RANGE`<br>`INT8RANGE`<br>`NUMRANGE`<br>`TSRANGE`<br>`TSTZRANGE`<br>`DATERANGE`](https://www.postgresql.org/docs/current/rangetypes.html) | :octicons-x-16: | |
 
-    **Domain types**
+    #### Domain types
 
     | Type | Supported | Notes |
     |------|------------|-------|
     | [`CREATE TABLE <table> (col <domain>)`](https://www.postgresql.org/docs/current/domains.html) | :octicons-x-16: | |
 
-    **Object identifier types**
+    #### Object identifier types
 
     | Type | Supported | Notes |
     |------|------------|-------|

--- a/docs/releases/readyset-core.md
+++ b/docs/releases/readyset-core.md
@@ -6,44 +6,30 @@ ReadySet releases a new version of ReadySet Core on a monthly basis. This page s
 
     Beta versions of ReadySet are backward-incompatible. To upgrade between beta versions, you must therefore clear all data files. Rolling upgrades will be supported with future ReadySet major releases.
 
-## beta-2023-02-16
+## beta-2023-02-15
 
 ### Downloads
-
-=== ":material-linux: Linux"
-
-    !!! note
-
-        ReadySet binaries for Linux require the OpenSSL 1.1.x package. OpenSSL 3.x+ is not currently supported.
-
-    Binary (linux-x84_64) | Sha256Sum
-    ----------------------|----------
-    [ReadySet Server](https://github.com/readysettech/readyset/releases/download/beta-2023-02-16/readyset-server-beta-2023-02-168.x86_64.tar.gz) | TBD
-    [ReadySet Adapter](https://github.com/readysettech/readyset/releases/download/beta-2023-02-16/readyset-beta-2023-02-16.x86_64.tar.gz) | TBD
-
-=== ":material-apple: Mac"
-
-    Binary (darwin-arm64) | Sha256Sum
-    ------------------------------|----------
-    [ReadySet Server](https://github.com/readysettech/readyset/releases/download/beta-2023-02-16/readyset-server-beta-2023-02-16.arm64.tar.gz) | TBD
-    [ReadySet Adapter](https://github.com/readysettech/readyset/releases/download/beta-2023-02-16/readyset-beta-2023-02-16.arm64.tar.gz) | TBD
 
 === ":material-docker: Docker"
 
     - ReadySet Server (linux-x84_64)
         ``` sh
-        docker pull public.ecr.aws/readyset/readyset-server:beta-2023-02-16
+        docker pull public.ecr.aws/readyset/readyset-server:beta-2023-02-15
         ```
 
     - ReadySet Adapter (linux-x84_64)
         ``` sh
-        docker pull public.ecr.aws/readyset/readyset:beta-2023-02-16
+        docker pull public.ecr.aws/readyset/readyset:beta-2023-02-15
         ```
 
 === ":material-source-repository: Source"
 
-    - [`zip`](https://github.com/readysettech/readyset/archive/refs/tags/beta-2023-02-16.zip)
-    - [`tar.gz`](https://github.com/readysettech/readyset/archive/refs/tags/beta-2023-02-16.tar.gz)
+    !!! note
+
+        This release does not include pre-built binaries. However, you can build binaries from source. For guidance, see the ReadySet [README](https://github.com/readysettech/readyset#development). 
+
+    - [`zip`](https://github.com/readysettech/readyset/archive/refs/tags/beta-2023-02-15.zip)
+    - [`tar.gz`](https://github.com/readysettech/readyset/archive/refs/tags/beta-2023-02-15.tar.gz)
 
 ### Changes
 

--- a/docs/releases/readyset-core.md
+++ b/docs/releases/readyset-core.md
@@ -6,6 +6,66 @@ ReadySet releases a new version of ReadySet Core on a monthly basis. This page s
 
     Beta versions of ReadySet are backward-incompatible. To upgrade between beta versions, you must therefore clear all data files. Rolling upgrades will be supported with future ReadySet major releases.
 
+## beta-2023-02-16
+
+### Downloads
+
+=== ":material-linux: Linux"
+
+    !!! note
+
+        ReadySet binaries for Linux require the OpenSSL 1.1.x package. OpenSSL 3.x+ is not currently supported.
+
+    Binary (linux-x84_64) | Sha256Sum
+    ----------------------|----------
+    [ReadySet Server](https://github.com/readysettech/readyset/releases/download/beta-2023-02-16/readyset-server-beta-2023-02-168.x86_64.tar.gz) | TBD
+    [ReadySet Adapter](https://github.com/readysettech/readyset/releases/download/beta-2023-02-16/readyset-beta-2023-02-16.x86_64.tar.gz) | TBD
+
+=== ":material-apple: Mac"
+
+    Binary (darwin-arm64) | Sha256Sum
+    ------------------------------|----------
+    [ReadySet Server](https://github.com/readysettech/readyset/releases/download/beta-2023-02-16/readyset-server-beta-2023-02-16.arm64.tar.gz) | TBD
+    [ReadySet Adapter](https://github.com/readysettech/readyset/releases/download/beta-2023-02-16/readyset-beta-2023-02-16.arm64.tar.gz) | TBD
+
+=== ":material-docker: Docker"
+
+    - ReadySet Server (linux-x84_64)
+        ``` sh
+        docker pull public.ecr.aws/readyset/readyset-server:beta-2023-02-16
+        ```
+
+    - ReadySet Adapter (linux-x84_64)
+        ``` sh
+        docker pull public.ecr.aws/readyset/readyset:beta-2023-02-16
+        ```
+
+=== ":material-source-repository: Source"
+
+    - [`zip`](https://github.com/readysettech/readyset/archive/refs/tags/beta-2023-02-16.zip)
+    - [`tar.gz`](https://github.com/readysettech/readyset/archive/refs/tags/beta-2023-02-16.tar.gz)
+
+### Changes
+
+TODO: Check for commits after https://github.com/readysettech/readyset/commit/a1aea25882307307f0f6704a83d4f50cbc7f411c
+
+- The [`--eviction-policy`](../reference/cli/readyset.md#-eviction-policy) CLI option now defaults to `lru`, which performs best for most workloads. [998dd34](https://github.com/readysettech/readyset/commit/998dd341701e325ec2e951496b54c39c1306f629)
+- The [`--username`](../reference/cli/readyset.md#-username) and [`--password`](../reference/cli/readyset.md#-password) CLI options now default to the username and password for the upstream database in the [`--upstream-db-url`](../reference/cli/readyset.md#-upstream-db-url) option. [8989d30](https://github.com/readysettech/readyset/commit/8989d30ddb97da9fc6ab91fa528ba2b8abe6472b)
+- Added a new `--worker-request-timeout-seconds` CLI option and `WORKER_REQUEST_TIMEOUT_SECONDS` environment variable for configuring the timeout for requests made to workers. [875d0da](https://github.com/readysettech/readyset/commit/875d0da5f181d403372eca31920761cc7bc5b2fa)
+- Improved error messages for [`CREATE CACHE`](../guides/cache-queries/#cache-queries_1) statements with queries that ReadySet is unable to parse. [1035e26](https://github.com/readysettech/readyset/commit/1035e262d8d3c5585296f19d2b64959687d42840)
+- The following Prometheus metrics no longer contain domain and
+shard tags, and have been renamed to have the `domain_` prefix removed:
+`domain_forward_time_us`, `domain_total_forward_time_us`,
+`domain_eviction_time_us`, `domain_node_state_size_bytes`,
+`domain_reader_state_size_bytes`, `domain_base_tables_estimated_size_bytes`,
+`domain_eviction_requests`, `domain_eviction_freed_memory`, and
+`domain_node_added`. [00305d9](https://github.com/readysettech/readyset/commit/00305d9b50ef1eea7efc2cc2650d9d8069c33acc)
+- When restarting ReadySet, changes to the [`--replication-tables`](../reference/cli/readyset/#-replication-tables) CLI option are now applied. [3151117](https://github.com/readysettech/readyset/commit/3151117554cb034826b91bcb589a11952ea684f2)
+- Fixed a bug where ReadySet running in PostgreSQL mode would return an error for queries with integer literals in the `SELECT` list. [f0062db](https://github.com/readysettech/readyset/commit/f0062db89f8f01deac1fb856de5a2a29640cfabd)
+- When ReadySet receives an unsupported value in the replication stream (e.g., `infinity` or `-infinity` for a Postgres date or timestamp), ReadySet now stops replicating the affected table and removes all caches accessing that table. This allows ReadySet to continue with the replication of other tables instead of retrying that replication event infinitely. [bc47adf](https://github.com/readysettech/readyset/commit/bc47adf6bff87a39805c3a551d92e68fc83677b8)
+- Fixed a bug that could, in certain cases, cause ReadySet to panic when executing a query that ReadySet is unable to parse. [caacfca](https://github.com/readysettech/readyset/commit/caacfca6192e7d220a0e19a9b480ebd98498cd75)
+- Fixed a bug that could cause snapshotting and replication to fail for deeply nested `JSON` values. [551dda8](https://github.com/readysettech/readyset/commit/551dda850f22824ae6f61c98a2be7ea89a14b1a7)
+
 ## beta-2023-01-18
 
 ### Downloads
@@ -58,7 +118,6 @@ ReadySet releases a new version of ReadySet Core on a monthly basis. This page s
 - Fixed a bug that caused replication to fail on Aurora Postgres version 13 databases. [9be6443](https://github.com/readysettech/readyset/commit/9be644320a7521d8f2c30c3fda811c7736c4fb26)
 - Fixed a bug that could cause a failure loop when replicating a table. [adc8f25](https://github.com/readysettech/readyset/commit/adc8f25e01f4e14b2b99e764785ec9b4dd6e7daa)
 - Fixed an issue where ReadySet would not correctly write out the row description or correct tag for `SELECT`s that return no results. [02b3fb6](https://github.com/readysettech/readyset/commit/02b3fb6b6c8a21509f6922956dd978e39105425c)
-
 
 ## beta-2022-12-15
 

--- a/docs/releases/readyset-core.md
+++ b/docs/releases/readyset-core.md
@@ -47,8 +47,7 @@ ReadySet releases a new version of ReadySet Core on a monthly basis. This page s
 
 ### Changes
 
-TODO: Check for commits after https://github.com/readysettech/readyset/commit/a1aea25882307307f0f6704a83d4f50cbc7f411c
-
+- Multiple instances of ReadySet can now be run against a single Postgres instance. [ab92510](https://github.com/readysettech/readyset/commit/ab92510e365bb585339c04e50c2acea2f7a71276)
 - The [`--eviction-policy`](../reference/cli/readyset.md#-eviction-policy) CLI option now defaults to `lru`, which performs best for most workloads. [998dd34](https://github.com/readysettech/readyset/commit/998dd341701e325ec2e951496b54c39c1306f629)
 - The [`--username`](../reference/cli/readyset.md#-username) and [`--password`](../reference/cli/readyset.md#-password) CLI options now default to the username and password for the upstream database in the [`--upstream-db-url`](../reference/cli/readyset.md#-upstream-db-url) option. [8989d30](https://github.com/readysettech/readyset/commit/8989d30ddb97da9fc6ab91fa528ba2b8abe6472b)
 - Added a new `--worker-request-timeout-seconds` CLI option and `WORKER_REQUEST_TIMEOUT_SECONDS` environment variable for configuring the timeout for requests made to workers. [875d0da](https://github.com/readysettech/readyset/commit/875d0da5f181d403372eca31920761cc7bc5b2fa)
@@ -65,6 +64,10 @@ shard tags, and have been renamed to have the `domain_` prefix removed:
 - When ReadySet receives an unsupported value in the replication stream (e.g., `infinity` or `-infinity` for a Postgres date or timestamp), ReadySet now stops replicating the affected table and removes all caches accessing that table. This allows ReadySet to continue with the replication of other tables instead of retrying that replication event infinitely. [bc47adf](https://github.com/readysettech/readyset/commit/bc47adf6bff87a39805c3a551d92e68fc83677b8)
 - Fixed a bug that could, in certain cases, cause ReadySet to panic when executing a query that ReadySet is unable to parse. [caacfca](https://github.com/readysettech/readyset/commit/caacfca6192e7d220a0e19a9b480ebd98498cd75)
 - Fixed a bug that could cause snapshotting and replication to fail for deeply nested `JSON` values. [551dda8](https://github.com/readysettech/readyset/commit/551dda850f22824ae6f61c98a2be7ea89a14b1a7)
+- Fixed an issue where the Postgres triggers that ReadySet installs for DDL replication could cause errors when attempting to create or alter types. [ef34ede](https://github.com/readysettech/readyset/commit/ef34ede425167f1958166f55992b42ea9eba1a72)
+- Fixed an error decoding parse messages with unspecified types. [9ca36fa](https://github.com/readysettech/readyset/commit/9ca36fa5e894dec278128db46447c98445c70cb1)
+- Fixed an issue where the ReadySet replicator wasn't gracefully handling every kind of Postgres connection failure. Now, the replicator will always retry in the event of a lost connection to the upstream database. [318be1d](https://github.com/readysettech/readyset/commit/318be1d00ed58b53bc1a67a51215f09ad4bb05b5)
+- Fixed an issue where executing prepared statements with `CITEXT` would fail with an unsupported error. [37ff026](https://github.com/readysettech/readyset/commit/37ff026b3a69d643b002e52eca41a265d1044a86)
 
 ## beta-2023-01-18
 


### PR DESCRIPTION
- Add Feb Core release notes. We've decided to release with just source and docker image this month.
- Document `NUMERIC` scale limitation.
- Document new defaults for `--username` and `--password`.
- Update quickstart docker compose config.