### PR TITLE
Revert the DEPLOYMENT_ENV value

### DIFF
--- a/docs/assets/docker-compose-postgres.yml
+++ b/docs/assets/docker-compose-postgres.yml
@@ -40,7 +40,7 @@ services:
       QUERY_LOG: "1"
       QUERY_LOG_AD_HOC: "1"
       DB_DIR: "/state"
-      DEPLOYMENT_ENV: docs_quickstart_postgres
+      DEPLOYMENT_ENV: quickstart_docker
       RS_API_KEY:
     volumes:
       - "readyset-state:/state"


### PR DESCRIPTION
Although we changed telemetry to accept random DEPLOYMENT_ENV values, the new value wasn't showing up in Segment. So this PR reverts to the previous value, which does still make it through.