### PR TITLE
Remove Material for MkDocs Insiders features

### DIFF
--- a/docs/guides/connect/index.md
+++ b/docs/guides/connect/index.md
@@ -17,16 +17,16 @@ Once you have a ReadySet instance up and running, you connect your application t
 
     Language | Driver | Tutorial
     ---------|----------------|---------
-    Node.js | [node-postgres](https://node-postgres.com/) | [Connect a Node.js App to ReadySet](nodejs.md#node-postgres)
-    Python | [psycopg2](https://www.psycopg.org/) | [Connect a Python App to ReadySet](python.md#psycopg2)
-    Ruby | [pg](https://rubygems.org/gems/pg/) | [Connect a Ruby App to ReadySet](ruby.md#pg)
-    Go | [pgx](https://github.com/jackc/pgx) | [Connect a Go App to ReadySet](python.md#pgx)
+    Node.js | [node-postgres](https://node-postgres.com/) | [Connect a Node.js App to ReadySet](nodejs.md)
+    Python | [psycopg2](https://www.psycopg.org/) | [Connect a Python App to ReadySet](python.md)
+    Ruby | [pg](https://rubygems.org/gems/pg/) | [Connect a Ruby App to ReadySet](ruby.md)
+    Go | [pgx](https://github.com/jackc/pgx) | [Connect a Go App to ReadySet](python.md)
 
 === "ORMS"
 
     Language | ORM | Tutorial
     ---------|-----|---------
-    Node.js | [Sequelize](https://sequelize.org/) | [Connect a Node.js App to ReadySet](nodejs.md#sequelize)
-    Python | [SQLAlchemy](https://www.sqlalchemy.org/) | [Connect a Python App to ReadySet](python.md#sqlalchemy)
-    Ruby | [ActiveRecord](https://guides.rubyonrails.org/active_record_basics.html) | [Connect a Ruby App to ReadySet](ruby.md#activerecord)
+    Node.js | [Sequelize](https://sequelize.org/) | [Connect a Node.js App to ReadySet](nodejs.md)
+    Python | [SQLAlchemy](https://www.sqlalchemy.org/) | [Connect a Python App to ReadySet](python.md)
+    Ruby | [ActiveRecord](https://guides.rubyonrails.org/active_record_basics.html) | [Connect a Ruby App to ReadySet](ruby.md)
     

--- a/docs/guides/deploy/deploy-readyset-cloud.md
+++ b/docs/guides/deploy/deploy-readyset-cloud.md
@@ -95,13 +95,15 @@ On your call with ReadySet, you'll ensure replication is enabled. The steps are 
 
         ``` sh
         PGPASSWORD=<password> psql \
-        --host=<database_endpoint> \ # (1)
+        --host=<database_endpoint> \
         --port=<port> \
         --username=<username> \
         --dbname=<database_name>
         ```
 
-        1.  To find the database endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
+        !!! tip 
+        
+            To find the database endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
 
     1. Check if [replication](https://www.postgresql.org/docs/current/logical-replication.html) is enabled:
 
@@ -186,14 +188,16 @@ On your call with ReadySet, you'll ensure replication is enabled. The steps are 
 
         ``` sh
         mysql \
-        --host=<database_endpoint> \ # (1)
+        --host=<database_endpoint> \ 
         --port=<port> \
         --user=<username> \
         --password=<password> \
         --database=<database_name>
         ```
 
-        1.  To find the database endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
+        !!! tip 
+        
+            To find the database endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
 
     1. In the `mysql` shell, verify that replication is enabled:
 
@@ -348,10 +352,12 @@ On your call with ReadySet, you'll ensure replication is enabled. The steps are 
     4. If the query is supported, use ReadySet's custom [`CREATE CACHE`](../cache/cache-queries.md#cache-queries_1) command to cache the query results in ReadySet:
 
         ``` sql
-        CREATE CACHE FROM <query>; -- (1)
+        CREATE CACHE FROM <query>;
         ```
 
-        1.   You can provide either the full `SELECT` text or the query ID listed in the `SHOW PROXIED QUERIES` output.
+        !!! tip 
+        
+            You can provide either the full `SELECT` text or the query ID listed in the `SHOW PROXIED QUERIES` output.
 
         Caching will take a few minutes, as it constructs the initial dataflow graph for the query and adds indexes to the relevant ReadySet table snapshots, as necessary. The `CREATE CACHE` command will return once this is complete.    
 

--- a/docs/guides/deploy/deploy-readyset-kubernetes.md
+++ b/docs/guides/deploy/deploy-readyset-kubernetes.md
@@ -56,12 +56,7 @@ This page shows you how to run ReadySet with Kubernetes on [Amazon EKS](https://
 
 ## Step 1. Start Kubernetes
 
-In this step, you'll create a Kubernetes cluster on Amazon EKS in the same VPC as your database. Your cluster will contain 3 nodes to accommodate a simple ReadySet deployment of one ReadySet Server, one ReadySet Adapter, and one instance of Consul.(1)
-{ .annotate }
-
-1.  - The ReadySet Server takes a snapshot of your underlying database, listens to the database's replication stream for updates, and keeps queries cached in an in-memory dataflow graph.
-      - The ReadySet Adapter handles connections from SQL clients and ORMs, forwarding uncached queries upstream and running cached queries against the ReadySet Server.
-      - Consul handles internal cluster state.
+In this step, you'll create a Kubernetes cluster on Amazon EKS in the same VPC as your database. Your cluster will contain 3 nodes to accommodate a simple ReadySet deployment of one ReadySet Server, one ReadySet Adapter, and one instance of Consul.
 
 For more demanding workloads, ReadySet can be run with multiple Adapters. Please [reach out](mailto:info@readyset.io) to ReadySet for guidance.
 
@@ -122,13 +117,15 @@ For more demanding workloads, ReadySet can be run with multiple Adapters. Please
 
             ``` sh
             PGPASSWORD=<password> psql \
-            --host=<database_endpoint> \ # (1)
+            --host=<database_endpoint> \
             --port=<port> \
             --username=<username> \
             --dbname=<database_name>
             ```
 
-            1.  To find the database endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
+            !!! tip 
+            
+                To find the database endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
 
             You should now be in the SQL shell, where you can query your database.
 
@@ -165,14 +162,16 @@ For more demanding workloads, ReadySet can be run with multiple Adapters. Please
 
             ``` sh
             mysql \
-            --host=<database_endpoint> \ # (1)
+            --host=<database_endpoint> \ 
             --port=<port> \
             --user=<username> \
             --password=<password> \
             --database=<database_name>
             ```
 
-            1.  To find the database endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
+            !!! tip 
+            
+                To find the database endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
 
             You should now be in the SQL shell, where you can query your database.
 
@@ -215,10 +214,12 @@ For more demanding workloads, ReadySet can be run with multiple Adapters. Please
             ```
 
             ``` sh
-            export RDS_ENDPOINT="<database_endpoint>" # (1)
+            export RDS_ENDPOINT="<database_endpoint>"
             ```
 
-            1.  To find the database endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
+            !!! tip 
+            
+                To find the database endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
 
             ```sh
             export CONN_STRING="postgresql://${DB_USERNAME}:${DB_PASSWORD}@${RDS_ENDPOINT}:5432/${DB_NAME}"
@@ -261,10 +262,12 @@ For more demanding workloads, ReadySet can be run with multiple Adapters. Please
             ```
 
             ``` sh
-            export RDS_ENDPOINT="<database_endpoint>" # (1)
+            export RDS_ENDPOINT="<database_endpoint>"
             ```
 
-            1.  To find the database endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
+            !!! tip 
+            
+                To find the database endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
 
             ```sh
             export CONN_STRING="mysql://${DB_USERNAME}:${DB_PASSWORD}@${RDS_ENDPOINT}:3306/${DB_NAME}"
@@ -324,13 +327,15 @@ In this step, you'll configure your database so that ReadySet can consume the da
 
         ``` sh
         PGPASSWORD=<password> psql \
-        --host=<database_endpoint> \ # (1)
+        --host=<database_endpoint> \ 
         --port=<port> \
         --username=<username> \
         --dbname=<database_name>
         ```
 
-        1.  To find the database endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
+        !!! tip 
+        
+            To find the database endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
 
     3. In the `psql` shell, check if [replication](https://www.postgresql.org/docs/current/logical-replication.html) is enabled:
 
@@ -426,14 +431,16 @@ In this step, you'll configure your database so that ReadySet can consume the da
 
         ``` sh
         mysql \
-        --host=<database_endpoint> \ # (1)
+        --host=<database_endpoint> \ 
         --port=<port> \
         --user=<username> \
         --password=<password> \
         --database=<database_name>
         ```
 
-        1.  To find the database endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
+        !!! tip 
+        
+            To find the database endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
 
 
     2. In the `mysql` shell, verify that replication is enabled:
@@ -555,7 +562,7 @@ In this step, you'll download and edit the configuration files for deploying Rea
           deploymentName: "readyset-helm-test""
         ```
 
-    1. Change the image tags for the ReadySet Server and Adapter from `latest` to the [latest release of the ReadySet Server and Adapter](../../releases/readyset-core.md#docker) (e.g., `beta-2023-01-18`):
+    1. Change the image tags for the ReadySet Server and Adapter from `latest` to the [latest release of the ReadySet Server and Adapter](../../releases/readyset-core.md) (e.g., `beta-2023-01-18`):
 
         !!! note
 

--- a/docs/guides/intro/intro.md
+++ b/docs/guides/intro/intro.md
@@ -37,14 +37,9 @@ ReadySet is particularly well-suited for the following cases:
 
 Integrating with ReadySet is straight-forward:
 
-<div class="annotate" markdown>
-
 1. Deploy ReadySet and connect it to your MySQL or Postgres database.
-2. Change your application's connection string to point at ReadySet.(1)
+2. Change your application's connection string to point at ReadySet.
 3. Cache queries using ReadySet's custom SQL commands.
-</div>
-
-1.  This is the only required change to your application.   
 
 To run through this process on your local machine on in your browser, see the [Quickstart](quickstart.md) or [Playground](playground.md).  
 

--- a/docs/guides/intro/quickstart.md
+++ b/docs/guides/intro/quickstart.md
@@ -190,13 +190,15 @@ With snapshotting finished, ReadySet is ready for caching, so in this step, you'
 1. Cache the query in ReadySet:
 
     ``` sql
-    CREATE CACHE FROM -- (1)
+    CREATE CACHE FROM
     SELECT count(*) FROM title_ratings
     JOIN title_basics ON title_ratings.tconst = title_basics.tconst
     WHERE title_basics.startyear = 2000 AND title_ratings.averagerating > 5;
     ```
 
-    1. To cache a query, you can provide either the full `SELECT` (as shown here) or the query ID listed in the `SHOW PROXIED QUERIES` output.
+    !!! tip 
+    
+        To cache a query, you can provide either the full `SELECT` (as shown here) or the query ID listed in the `SHOW PROXIED QUERIES` output.
 
     !!! note
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,64 +4,77 @@ hide:
   - toc
 ---
 
-
 # ReadySet Docs
 
 ReadySet is a lightweight SQL caching engine that sits between your application and database and turns even the most complex SQL reads into lightning-fast lookups. Unlike other caching solutions, ReadySet keeps the cache up-to-date automatically and requires no changes to your application code.
 
-<div class="grid cards" markdown>
+<style>
+* {
+  box-sizing: border-box;
+}
 
--   :material-lightbulb-outline:{ .lg .middle } [__About ReadySet__](guides/intro/intro.md)
+/* Create three equal columns that floats next to each other */
+.column {
+  float: left;
+  width: 33.33%;
+  padding: 10px;
+  /* height: 300px; Should be removed. Only for demonstration */
+}
 
-    ---
+/* Clear floats after the columns */
+.row:after {
+  content: "";
+  display: table;
+  clear: both;
+}
 
-    Learn how ReadySet works and when it's a good fit for an application
+/* Responsive layout - makes the three columns stack on top of each other instead of next to each other */
+@media screen and (max-width: 600px) {
+  .column {
+    width: 100%;
+  }
+}
+</style>
 
--   :material-rocket-launch-outline:{ .lg .middle } [__Quickstart__](guides/intro/quickstart.md)
-
-    ---
-
-    Get started with a local deployment of Postgres and ReadySet
-
--   :material-play-circle-outline:{ .lg .middle } [__Playground__](guides/intro/playground.md)
-
-    ---
-
-    Interact with ReadySet directly in your browser
-
--   :material-cloud-outline:{ .lg .middle } [__Run with ReadySet Cloud__](guides/deploy/deploy-readyset-cloud.md)
-
-    ---
-
-    Get early access to a fully-managed deployment of ReadySet
-
--   :material-file-code-outline:{ .lg .middle } [__Run with Binary__](guides/deploy/deploy-readyset-binary.md)
-
-    ---
-
-    Deploy ReadySet yourself with the ReadySet binary
-
--   :material-kubernetes:{ .lg .middle } [__Run with Kubernetes__](guides/deploy/deploy-readyset-kubernetes.md)
-
-    ---
-
-    Deploy ReadySet yourself with the ReadySet Helm chart
-
--   :octicons-link-24:{ .lg .middle } [__Connect an app__](guides/connect/index.md)
-
-    ---
-
-    Connect your application by swapping out your database connection string
-
--   :material-clock-fast:{ .lg .middle } [__Cache Queries__](guides/cache/cache-queries.md)
-
-    ---
-
-    Identify supported queries and cache their results in-memory
-
--   :material-check-all:{ .lg .middle } [__SQL Support__](reference/sql-support.md)
-
-    ---
-
-    Find out which parts of the SQL language are supported by ReadySet
+<div class="row">
+  <div class="column">
+    <a href="guides/intro/intro/"><h4>About ReadySet</h4></a>
+    <p>Learn how ReadySet works and when it's a good fit for an application</p>
+  </div>
+  <div class="column">
+    <a href="guides/intro/quickstart/"><h4>Quickstart</h4></a>
+    <p>Get started with a local deployment of Postgres and ReadySet</p>
+  </div>
+  <div class="column">
+    <a href="guides/intro/playground/"><h4>Playground</h4></a>
+    <p>Interact with ReadySet directly in your browser</p>
+  </div>
+</div>
+<div class="row">
+  <div class="column">
+    <a href="guides/deploy/deploy-readyset-cloud/"><h4>Run with ReadySet Cloud</h4></a>
+    <p>Get early access to a fully-managed deployment of ReadySet</p>
+  </div>
+  <div class="column">
+    <a href="guides/deploy/deploy-readyset-binary/"><h4>Run with Binary</h4></a>
+    <p>Deploy ReadySet yourself with the ReadySet binary</p>
+  </div>
+  <div class="column">
+    <a href="guides/deploy/deploy-readyset-kubernetes/"><h4>Run with Kubernetes</h4></a>
+    <p>Deploy ReadySet yourself with the ReadySet Helm chart</p>
+  </div>
+</div>
+<div class="row">
+  <div class="column">
+    <a href="guides/connect/"><h4>Connect an App</h4></a>
+    <p>Connect your application by swapping out your database connection string</p>
+  </div>
+  <div class="column">
+    <a href="guides/cache/cache-queries/"><h4>Cache Queries</h4></a>
+    <p>Identify supported queries and cache their results in-memory</p>
+  </div>
+  <div class="column">
+    <a href="reference/sql-support/"><h4>SQL Support</h4></a>
+    <p>Find out which parts of the SQL language are supported by ReadySet</p>
+  </div>
 </div>


### PR DESCRIPTION
In preparation for downgrading from the paid "Insiders"
subscription of the Material for MkDocs theme:
- Remove use of annotations.
- Remove card grids on docs home and replicate approximately with css.
- Remove anchor links to tabs.

Fixes: DOC-128